### PR TITLE
GitHub Action to fetch OAS yaml and generate SDK automatically

### DIFF
--- a/.github/workflows/api-docs-generator.yml
+++ b/.github/workflows/api-docs-generator.yml
@@ -1,0 +1,123 @@
+name: PHP SDK Generator
+
+env:
+  FETCH_CMD: 'wget https://znanylekarz.pl/openapi/integrations-api.yaml -d --header="X-OAS-INTEGRATIONS-TOKEN: ${{ secrets.OPENAPI_INTEGRATIONS_SPECIFICATION_TOKEN }}"'
+  FILE_NAME: integrations-api.yaml
+  BRANCH: actions/generate-sdk
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - actions/generate-sdk
+
+jobs:
+  diff:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      diff: ${{ steps.checksum.outputs.diff }}
+    steps:
+      - name: Fetch yaml specification file
+        run: ${{ env.FETCH_CMD }}
+      - name: Check cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.FILE_NAME }}
+          key: oas--${{ hashFiles(env.FILE_NAME) }}
+      - name: Stop process (no changes)
+        id: checksum
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: echo "::set-output name=diff::true"
+      - name: Generate specification artifacts
+        if: steps.checksum.outputs.diff != 'false'
+        uses: actions/upload-artifact@v2
+        with:
+          name: specification
+          path: ${{ env.FILE_NAME }}
+  generate:
+    needs: diff
+    if: needs.diff.outputs.diff != 'false'
+    name: Generate SDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+      - name: Download specification artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: specification
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Download swagger codegen
+        run: wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.24/swagger-codegen-cli-3.0.24.jar -O swagger-codegen-cli.jar
+      - name: Generate SDK files
+        run: java -jar swagger-codegen-cli.jar generate --git-user-id=DocPlanner --git-repo-id integrations-api-sdk-php -DinvokerPackage=DocPlanner\\Client -i ${{ env.FILE_NAME }} -l php -o ./final/
+      - name: Patch library files
+        run: cp -r final/SwaggerClient-php/docs/* docs/
+      - name: Patch docs files
+        run: cp -r final/SwaggerClient-php/lib/* lib/
+      - name: Commit files
+        id: commit
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions"
+          git add lib/ docs/
+          if [ -z "$(git status -uno --porcelain)" ]; then
+             echo "::set-output name=push::false"
+          else
+             git commit -m "Generate SDK" -a
+             echo "::set-output name=push::true"
+          fi
+        shell: bash
+      - name: Push changes
+        if: steps.commit.outputs.push == 'true'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.BRANCH }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v1.0.${{ github.run_number }}
+          release_name: Release v1.0.${{ github.run_number }}
+          body: |
+            Generated automatically
+          draft: true
+          prerelease: false
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: specification
+      - name: Send Slack notification on success
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: integrations_notifications
+          SLACK_COLOR: '#36a64f'
+          SLACK_ICON: https://github.com/swagger-api.png
+          SLACK_MESSAGE: 'PHP SDK generated. Release URL: ${{ steps.create_release.outputs.html_url }}'
+          SLACK_TITLE: Success
+          SLACK_USERNAME: Github Actions
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}
+      - name: Send Slack notification on failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: integrations_notifications
+          SLACK_COLOR: '#cb2431'
+          SLACK_ICON: https://github.com/swagger-api.png
+          SLACK_MESSAGE: 'Failed to generate PHP SDK'
+          SLACK_TITLE: Failure
+          SLACK_USERNAME: Github Actions
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}

--- a/.github/workflows/api-docs-generator.yml
+++ b/.github/workflows/api-docs-generator.yml
@@ -3,7 +3,7 @@ name: PHP SDK Generator
 env:
   FETCH_CMD: 'wget https://znanylekarz.pl/openapi/integrations-api.yaml -d --header="X-OAS-INTEGRATIONS-TOKEN: ${{ secrets.OPENAPI_INTEGRATIONS_SPECIFICATION_TOKEN }}"'
   FILE_NAME: integrations-api.yaml
-  BRANCH: actions/generate-sdk
+  BRANCH: develop
 
 on:
   schedule:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - actions/generate-sdk
+      - develop
 
 jobs:
   diff:


### PR DESCRIPTION
It publishes draft release, so it has to be manually published.
Example action:
https://github.com/DocPlanner/integrations-api-sdk-php/actions/runs/541000897
Notification:
![image](https://user-images.githubusercontent.com/13415865/107063688-f5d76e80-67da-11eb-8f7a-d75145bb67a6.png)

